### PR TITLE
DDCE-2441 - correct styling in summary page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -60,3 +60,9 @@ p {
 h2 {
  @extend .govuk-heading-m
 }
+
+@media (min-width: 40.0625em) {
+  .govuk-summary-list__value {
+    width: 50%;
+  }
+}


### PR DESCRIPTION
When upgrading govuk frontend we noticed changes to the summary page styling.

This is to fix the noticed change that will fix an issue that allows enough space for the answers to fit nicely on the page.
